### PR TITLE
Bugfix: remove mouse movement loop in which it doesn't allow manual mouse movement

### DIFF
--- a/src/awake.py
+++ b/src/awake.py
@@ -13,8 +13,6 @@ while(True):
     while(x<numMin):
         time.sleep(60)
         x+=1
-    for i in range(0,200):
-        pyautogui.moveTo(0,i*4)
     pyautogui.moveTo(1,1)
     for i in range(0,3):
         pyautogui.press("shift")


### PR DESCRIPTION
Tested on Windows 11 laptop